### PR TITLE
Исправление крафтов терминалов AE2

### DIFF
--- a/kubejs/server_scripts/ae2/recipes.js
+++ b/kubejs/server_scripts/ae2/recipes.js
@@ -190,7 +190,7 @@ const registerAE2Recipes = (event) => {
         'FEF'
     ], {
         A: 'ae2:wireless_receiver',
-        B: 'ae2:crafting_terminal',
+        B: 'ae2:terminal',
         C: 'ae2:engineering_processor',
         D: '#forge:circuits/hv',
         E: 'gtceu:hv_lithium_battery',

--- a/kubejs/server_scripts/ae2wtlib/recipes.js
+++ b/kubejs/server_scripts/ae2wtlib/recipes.js
@@ -13,7 +13,7 @@ const registerAE2WTLibRecipes = (event) => {
     // Wireless Pattern Terminal
     event.recipes.gtceu.assembler('ae2wtlib:wireless_pattern_encoding_terminal')
         .itemInputs(
-            '4x gtceu:lapotronic_energy_orb',
+            '2x gtceu:hv_lithium_battery',
             'ae2:wireless_terminal',
             'ae2:pattern_encoding_terminal',
             '2x gtceu:luv_sensor',
@@ -27,7 +27,7 @@ const registerAE2WTLibRecipes = (event) => {
     // Pattern Access Terminal
     event.recipes.gtceu.assembler('ae2wtlib:wireless_pattern_access_terminal')
         .itemInputs(
-            '4x gtceu:lapotronic_energy_orb',
+            '2x gtceu:hv_lithium_battery',
             'ae2:wireless_terminal',
             'ae2:pattern_access_terminal',
             '2x gtceu:luv_sensor',

--- a/kubejs/server_scripts/ae2wtlib/recipes.js
+++ b/kubejs/server_scripts/ae2wtlib/recipes.js
@@ -13,7 +13,7 @@ const registerAE2WTLibRecipes = (event) => {
     // Wireless Pattern Terminal
     event.recipes.gtceu.assembler('ae2wtlib:wireless_pattern_encoding_terminal')
         .itemInputs(
-            '2x ae2:dense_energy_cell',
+            '4x gtceu:lapotronic_energy_orb',
             'ae2:wireless_terminal',
             'ae2:pattern_encoding_terminal',
             '2x gtceu:luv_sensor',
@@ -27,7 +27,7 @@ const registerAE2WTLibRecipes = (event) => {
     // Pattern Access Terminal
     event.recipes.gtceu.assembler('ae2wtlib:wireless_pattern_access_terminal')
         .itemInputs(
-            '2x ae2:dense_energy_cell',
+            '4x gtceu:lapotronic_energy_orb',
             'ae2:wireless_terminal',
             'ae2:pattern_access_terminal',
             '2x gtceu:luv_sensor',


### PR DESCRIPTION
## Что
_В этом разделе описывается суть данного PR. Это должно быть четкое и краткое описание того, для чего предназначен этот PR, почему он необходим и почему его следует принять._
_Связывание проблемы можно использовать вместо написания описания._
нужно изменить неправильный крафт беспроводного терминала и вернуть крафт остальным терминалам 

## Детали реализации
_Любые реализации в этом PR, которые следует тщательно изучить или для которых могут/должны быть предложены альтернативные решения._
для возвращения крафтов остальных терминалов заменил dense_energy_cell на литиум батарею hv как в крафте беспроводного крафтинг терминала 
![image](https://github.com/TerraFirmaGreg-Team/Modpack-1.20.x/assets/112543401/8712267b-1148-4887-98ae-1058affd3a93)

![image](https://github.com/TerraFirmaGreg-Team/Modpack-1.20.x/assets/112543401/861b8ca4-a7b1-40bf-9111-f7f68b63ebaf)
![image](https://github.com/TerraFirmaGreg-Team/Modpack-1.20.x/assets/112543401/18e92716-b24f-4bac-8643-ea62646388ab)

## Исход
_Краткое описание того, что добавлено/исправлено/изменено/удалено в этом PR._
_Для правильного связывания проблем используйте любое из ключевых слов Closes/Fixes/Resolves. Пример: когда PR исправляет ошибку, используйте «Исправления: #номер-ошибки»_.
изменил крафты беспроводных терминалов 

## Дополнительная информация
_Этот раздел предназначен для снимков экрана или любой другой дополнительной информации, о которой рецензенты должны знать._
крафты терминалов из wtlib не работали изза dense_energy_cell который я заменил на литиум батареи hv