### PR TITLE
Update Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </a>
   <br/>
 
-  <a href="https://discord.gg/terrafirmagreg">
+  <a href="https://discord.com/invite/AEaCzCTUwQ">
   <img src="https://cdn.jsdelivr.net/npm/@intergrav/devins-badges/assets/compact-minimal/social/discord-singular_vector.svg" alt="Chat on Discord"></a>
 
   <a href="https://www.curseforge.com/minecraft/modpacks/terrafirmagreg/files?page=1&pageSize=20&version=1.20.1">


### PR DESCRIPTION
The old link is invalid

I got the new link from the team's README on GitHub