### PR TITLE
Temporal fix for #364

### DIFF
--- a/kubejs/server_scripts/sophisticated_backpacks/recipes.js
+++ b/kubejs/server_scripts/sophisticated_backpacks/recipes.js
@@ -3,7 +3,7 @@
 const registerSophisticatedBackpacksRecipes = (event) => {
 
     // Удаление рецептов мода sophisticatedBackpacks
-    event.remove({ mod: 'sophisticatedbackpacks' })
+    event.remove({ mod: 'sophisticatedbackpacks', not: {type: 'sophisticatedbackpacks:backpack_dye'} })
 
     // Рюкзаки
 


### PR DESCRIPTION
## What is it?
Temporal fix for #364, now backpacks can be dyed, both belt and pack. However, GTM chemical dyes can also be used for recipes, which is not expected. Besides, backpacks cannot be dyed in chemical bath machines. The difficulty to fix these bugs is that I have not figured out how to set dyed color, since it's not replacing but mixing with original color.